### PR TITLE
Add auth token headers to OTLP exporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,10 @@ http://localhost:4318/v1/traces
 
 Logs y métricas pueden ser enviados desde el backend o con wrappers personalizados.
 
+Al iniciar sesión en la aplicación se obtiene un token (por ejemplo un JWT) que
+se almacena en `localStorage` bajo la clave `auth_token`. Dicho token se usa
+posteriormente para firmar las peticiones de los exportadores OTLP.
+
 ---
 
 ## 🔐 Accesos por defecto

--- a/src/telemetry/otel-init.ts
+++ b/src/telemetry/otel-init.ts
@@ -24,14 +24,18 @@ const resource = resourceFromAttributes({
   [ATTR_NETWORK_PROTOCOL_VERSION]: '1.0',
   app: 'angular-frontend',
 });
+// Token obtenido tras el flujo de login (guardado en localStorage)
+const token = localStorage.getItem('auth_token');
 // Configura el exportador OTLP con la URL de tu backend de trazas
 const exporter = new OTLPTraceExporter({
   url: 'http://localhost:4318/v1/traces',
+  headers: token ? { Authorization: `Bearer ${token}` } : {},
 });
 // ==== METRICS PROVIDER ====
 
 const metricExporter = new OTLPMetricExporter({
   url: 'http://localhost:4318/v1/metrics',
+  headers: token ? { Authorization: `Bearer ${token}` } : {},
 });
 
 const metricReader = new PeriodicExportingMetricReader({


### PR DESCRIPTION
## Summary
- include bearer token header when creating OTLP exporters
- document where the token comes from

## Testing
- `npm test --silent` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684af5d290488331b81f9edede7ab96c